### PR TITLE
✨ zellij ステータスバーに zjstatus を導入し cwd を常時表示

### DIFF
--- a/config/platform-files.conf
+++ b/config/platform-files.conf
@@ -49,6 +49,7 @@ Microsoft.PowerShell_profile.ps1:~/Documents/WindowsPowerShell/Microsoft.PowerSh
 
 # Zellij terminal multiplexer
 .config/zellij/config.kdl:~/.config/zellij/config.kdl:macos,linux
+.config/zellij/layouts/default.kdl:~/.config/zellij/layouts/default.kdl:macos,linux
 .config/zellij/layouts/claude-code.kdl:~/.config/zellij/layouts/claude-code.kdl:macos,linux
 
 # WezTerm terminal

--- a/src/.config/zellij/config.kdl
+++ b/src/.config/zellij/config.kdl
@@ -11,6 +11,9 @@ on_force_close "detach"
 show_startup_tips false
 show_release_notes false
 
+// Default layout (custom, adds zjstatus cwd indicator)
+default_layout "default"
+
 keybinds clear-defaults=true {
     locked {
         bind "Ctrl g" { SwitchToMode "normal"; }

--- a/src/.config/zellij/layouts/claude-code.kdl
+++ b/src/.config/zellij/layouts/claude-code.kdl
@@ -11,7 +11,32 @@ layout {
         }
         pane size="30%" name="shell"
     }
-    pane size=1 borderless=true {
-        plugin location="status-bar"
+    pane size=2 borderless=true {
+        plugin location="https://github.com/dj95/zjstatus/releases/latest/download/zjstatus.wasm" {
+            format_left   "{mode} #[fg=#89B4FA,bold]{session} "
+            format_center "{tabs}"
+            format_right  "#[fg=#a6e3a1,bold] {pipe_cwd} #[fg=#6C7086]│ {datetime}"
+            format_space  ""
+
+            hide_frame_for_single_pane "true"
+
+            mode_normal  "#[bg=#89B4FA,fg=#1e1e2e,bold] NORMAL "
+            mode_locked  "#[bg=#f38ba8,fg=#1e1e2e,bold] LOCKED "
+            mode_pane    "#[bg=#a6e3a1,fg=#1e1e2e,bold] PANE "
+            mode_tab     "#[bg=#cba6f7,fg=#1e1e2e,bold] TAB "
+            mode_resize  "#[bg=#fab387,fg=#1e1e2e,bold] RESIZE "
+            mode_scroll  "#[bg=#f9e2af,fg=#1e1e2e,bold] SCROLL "
+            mode_search  "#[bg=#94e2d5,fg=#1e1e2e,bold] SEARCH "
+            mode_session "#[bg=#89dceb,fg=#1e1e2e,bold] SESSION "
+
+            tab_normal   "#[fg=#6C7086] {index} {name} "
+            tab_active   "#[fg=#f9e2af,bold] {index} {name} "
+
+            pipe_cwd_format "{output}"
+
+            datetime          "#[fg=#6C7086] {format}"
+            datetime_format   "%Y-%m-%d %H:%M"
+            datetime_timezone "Asia/Tokyo"
+        }
     }
 }

--- a/src/.config/zellij/layouts/default.kdl
+++ b/src/.config/zellij/layouts/default.kdl
@@ -1,0 +1,39 @@
+// Default layout with zjstatus status bar
+// Provides: mode, tabs, session name, cwd (via pipe from shell), datetime
+
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
+        children
+        pane size=2 borderless=true {
+            plugin location="https://github.com/dj95/zjstatus/releases/latest/download/zjstatus.wasm" {
+                format_left   "{mode} #[fg=#89B4FA,bold]{session} "
+                format_center "{tabs}"
+                format_right  "#[fg=#a6e3a1,bold] {pipe_cwd} #[fg=#6C7086]│ {datetime}"
+                format_space  ""
+
+                hide_frame_for_single_pane "true"
+
+                mode_normal  "#[bg=#89B4FA,fg=#1e1e2e,bold] NORMAL "
+                mode_locked  "#[bg=#f38ba8,fg=#1e1e2e,bold] LOCKED "
+                mode_pane    "#[bg=#a6e3a1,fg=#1e1e2e,bold] PANE "
+                mode_tab     "#[bg=#cba6f7,fg=#1e1e2e,bold] TAB "
+                mode_resize  "#[bg=#fab387,fg=#1e1e2e,bold] RESIZE "
+                mode_scroll  "#[bg=#f9e2af,fg=#1e1e2e,bold] SCROLL "
+                mode_search  "#[bg=#94e2d5,fg=#1e1e2e,bold] SEARCH "
+                mode_session "#[bg=#89dceb,fg=#1e1e2e,bold] SESSION "
+
+                tab_normal   "#[fg=#6C7086] {index} {name} "
+                tab_active   "#[fg=#f9e2af,bold] {index} {name} "
+
+                pipe_cwd_format "{output}"
+
+                datetime          "#[fg=#6C7086] {format}"
+                datetime_format   "%Y-%m-%d %H:%M"
+                datetime_timezone "Asia/Tokyo"
+            }
+        }
+    }
+}

--- a/src/.zshrc
+++ b/src/.zshrc
@@ -97,6 +97,19 @@ if command -v zoxide &> /dev/null; then
   eval "$(zoxide init zsh)"
 fi
 
+# zellij zjstatus: push cwd to status bar via pipe
+if [ -n "${ZELLIJ:-}" ] && command -v zellij &> /dev/null; then
+  _zjstatus_cwd_pipe() {
+    zellij pipe \
+      --plugin 'https://github.com/dj95/zjstatus/releases/latest/download/zjstatus.wasm' \
+      --name 'zjstatus::pipe::pipe_cwd' \
+      -- "$PWD" 2>/dev/null
+  }
+  autoload -U add-zsh-hook
+  add-zsh-hook precmd _zjstatus_cwd_pipe
+  add-zsh-hook chpwd _zjstatus_cwd_pipe
+fi
+
 # Starship (must be at the end)
 if command -v starship &> /dev/null; then
   eval "$(starship init zsh)"


### PR DESCRIPTION

## 📒 変更の概要

- 🆕 `default.kdl` レイアウトを新規作成し、`zjstatus` プラグインを追加しました。
- 🔧 `config.kdl` にデフォルトレイアウトを設定しました。
- 📜 `claude-code.kdl` のレイアウトを更新し、`zjstatus` プラグインを統合しました。
- 📝 `.zshrc` に `zjstatus` のカレントワーキングディレクトリ (cwd) をステータスバーに表示するためのパイプ処理を追加しました。

## ⚒ 技術的詳細

- `default.kdl` では、`zjstatus` プラグインを使用して、モード、タブ、セッション名、カレントワーキングディレクトリ (cwd)、および日時を表示するレイアウトを定義しました。
- `zjstatus` プラグインは、GitHubから直接取得され、ステータスバーに情報を表示します。
- `.zshrc` に追加されたスクリプトは、`zellij` が起動するたびにカレントディレクトリを `zjstatus` に送信します。

## ⚠ 注意点

- ⚠️ この変更により、`zellij` の使用時に `zjstatus` プラグインが必要になります。プラグインが正しく動作するためには、インターネット接続が必要です。
- ⚠️ `zjstatus` プラグインのバージョンが更新された場合、表示内容や動作が変更される可能性がありますので、注意が必要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Terminal Configuration**: Enhanced default terminal layout with improved status bar displaying current mode, session, open tabs, working directory, and system time.
* **Shell Integration**: Added automatic directory synchronization with the status bar when navigating directories in the shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->