### PR TITLE
📝 zellij ワークフローのドキュメント拡充と ccw ショートカットの追加

### DIFF
--- a/docs/zellij-claude-workflow.ja.md
+++ b/docs/zellij-claude-workflow.ja.md
@@ -146,6 +146,7 @@ Zellij タブを追加で作る:
 | `cmd + t` | 新規タブ |
 | `cmd + w` | タブを閉じる |
 | `cmd + shift + [` / `]` | タブ切替 |
+| `cmd + shift + click` | URL を開く（zellij バイパス） |
 | `cmd + r` | fzf 履歴検索（`ctrl+r` にリマップ） |
 
 ### Zellij モード切替（プレフィックス）
@@ -278,6 +279,14 @@ mise でインストールしている場合、zellij のログイン時点で m
 - `zellij list-sessions` で EXITED 状態になっているか確認
 - `session_serialization true` が有効か `config.kdl` を確認
 - キャッシュ: `~/Library/Caches/org.Zellij-Contributors.Zellij/` or `~/.cache/zellij/`
+
+### URL をマウスクリックで開けない／テキスト選択できない
+
+zellij がマウスイベントを捕捉しているため、ターミナル出力中の URL を普通にクリックしても Ghostty まで届かない。
+
+**対処**: `cmd + shift + クリック` で URL を開く。テキスト選択したい場合は `cmd + shift + ドラッグ`。`cmd` か `shift` 単体ではバイパスできず、同時押しが必要。
+
+**恒久対応（オプション）**: `src/.config/zellij/config.kdl` に `mouse_mode false` を追加すれば、zellij のマウスキャプチャを無効化してマウス操作を常に Ghostty 側へ渡せる。ただし zellij のマウス操作（ペインクリック切替、タブクリック、ドラッグリサイズ等）は使えなくなるトレードオフを伴う。通常は上記ショートカットで十分。
 
 ### Ghostty のキーバインドと衝突した
 

--- a/src/.shell_common
+++ b/src/.shell_common
@@ -31,6 +31,7 @@ Aliases:
     gl        git log --oneline
     gnf       git new-feature-branch
     gclean    delete stale local branches (-f to force)
+    ccw       Claude Code を worktree sandbox で起動してブレスト開始
 
   Files:
     ls        eza --icons
@@ -90,6 +91,22 @@ if command -v git &> /dev/null; then
     fi
   }
   alias gclean='git_cleanup_branches'
+
+  # Claude Code を worktree sandbox で起動し、そのままブレストに入る
+  # Usage: ccw [トピック...]
+  ccw() {
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      echo "ccw: not inside a git repository" >&2
+      return 1
+    fi
+    if ! command -v claude >/dev/null 2>&1; then
+      echo "ccw: claude command not found" >&2
+      return 1
+    fi
+
+    local topic="${*:-（トピックはこれから相談する）}"
+    claude "git:worktree スキルの Start フェーズを実行して、最新の base ブランチから新しい worktree を作成してください。作成後すぐに superpowers:brainstorming スキルを起動して、次のトピックでブレストを始めてください: ${topic}"
+  }
 fi
 
 # eza (ls replacement)


### PR DESCRIPTION

このプルリクエストでは、`zellij` ワークフローに関するドキュメントを拡充し、新しいショートカット `ccw` を追加しました。

## 📒 変更の概要

- 📄 `docs/zellij-claude-workflow.ja.md` に以下の内容を追加しました:
  - `cmd + shift + click` で URL を開く方法を追加。
  - マウスクリックで URL を開けない場合の対処法を記載。
  - `mouse_mode false` を設定することで zellij のマウスキャプチャを無効化する恒久対応のオプションを追加。

- 🛠️ `src/.shell_common` に `ccw` ショートカットを追加しました:
  - `ccw` コマンドを使用することで、`Claude Code` を worktree sandbox で起動し、ブレインストーミングを開始できます。

## ⚒ 技術的詳細

- `docs/zellij-claude-workflow.ja.md` の変更:
  - 新しいショートカット `cmd + shift + click` により、zellij 内での URL 開放が可能になりました。
  - マウスイベントの捕捉に関する注意点とその対処法を明記しました。

- `src/.shell_common` の変更:
  - `ccw` コマンドは、git リポジトリ内でのみ機能し、`claude` コマンドが存在することを確認します。トピックを指定しない場合はデフォルトのメッセージが使用されます。

## ⚠ 注意点

- ⚠️ `mouse_mode false` を設定すると、zellij のマウス操作が無効化されるため、ペインの切替やタブのクリック、ドラッグリサイズなどができなくなります。この設定は必要に応じて使用してください。
- ⚠️ `ccw` コマンドは、git リポジトリ内でのみ実行可能です。リポジトリ外で実行するとエラーメッセージが表示されます。