### PR TITLE
🐛 zellij pipe のブロッキングを回避する修正

### DIFF
--- a/src/.shell_common
+++ b/src/.shell_common
@@ -166,13 +166,18 @@ if command -v zellij &> /dev/null; then
   }
 
   # Push current working directory to zjstatus status bar (pipe_cwd).
+  # zellij pipe without --plugin can block waiting for a plugin response,
+  # so we fire-and-forget in a backgrounded subshell and dedupe on $PWD.
+  _zj_last_cwd=""
   _zj_pipe_cwd() {
     [ -z "${ZELLIJ:-}" ] && return 0
-    zellij pipe --name "zjstatus::pipe::cwd" -- "${PWD/#$HOME/~}" >/dev/null 2>&1 || true
+    [ "$PWD" = "${_zj_last_cwd:-}" ] && return 0
+    _zj_last_cwd="$PWD"
+    ( zellij pipe --name "zjstatus::pipe::cwd" -- "${PWD/#$HOME/~}" >/dev/null 2>&1 & ) 2>/dev/null
   }
   if [ -n "${ZSH_VERSION:-}" ]; then
     autoload -Uz add-zsh-hook 2>/dev/null && add-zsh-hook chpwd _zj_pipe_cwd
-    add-zsh-hook precmd _zj_pipe_cwd 2>/dev/null || true
+    _zj_pipe_cwd
   elif [ -n "${BASH_VERSION:-}" ]; then
     case "${PROMPT_COMMAND:-}" in
       *_zj_pipe_cwd*) ;;


### PR DESCRIPTION

## 📒 変更の概要

- `src/.shell_common` ファイルにおいて、`zellij pipe` のブロッキングを回避するための修正が行われました。

## ⚒ 技術的詳細

- `zellij pipe` を使用する際に、`--plugin` オプションなしでブロックされる問題を解決するために、バックグラウンドのサブシェルで非同期に実行するように変更されました。
- 現在の作業ディレクトリを `zjstatus` ステータスバーにプッシュする `_zj_pipe_cwd` 関数が修正され、重複を避けるために `$PWD` の値をチェックするロジックが追加されました。

## ⚠ 注意点

- この変更により、`zellij pipe` の動作が非同期になるため、他の部分での依存関係に影響を与える可能性があります。動作確認を行うことをお勧めします。