### PR TITLE
Ctrl+q を Quit に戻す変更

### DIFF
--- a/src/.config/zellij/config.kdl
+++ b/src/.config/zellij/config.kdl
@@ -191,7 +191,7 @@ keybinds clear-defaults=true {
         bind "Alt o" { MoveTab "right"; }
         bind "Alt p" { TogglePaneInGroup; }
         bind "Alt Shift p" { ToggleGroupMarking; }
-        bind "Ctrl q" { Detach; }
+        bind "Ctrl q" { Quit; }
     }
     shared_except "locked" "move" {
         bind "Ctrl h" { SwitchToMode "move"; }


### PR DESCRIPTION

## 📒 Summary of Changes

- 🔄 `Ctrl+q` の動作を `Detach` から `Quit` に変更しました。

## ⚒ Technical Details

- 🔧 `src/.config/zellij/config.kdl` ファイル内のキーバインド設定を更新しました。これにより、`Ctrl+q` を押すと、ターミナルセッションが終了するようになります。

## ⚠ Points of Caution

- ⚠️ この変更により、`Ctrl+q` の動作が変更されるため、既存のユーザーは新しい動作に慣れる必要があります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated keyboard shortcut behavior for improved terminal session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->