### PR TITLE
🐛 ccw の --worktree sandbox を hook 許可パスと整合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,4 @@ src/.claude.json
 
 ### Git worktrees ###
 .worktrees/
+.claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ just tf -chdir=prod/bootstrap apply
 ## Worktree Workflow
 
 - 実装を伴う作業では `ccw <topic>` で Claude Code を起動すること
-- `.worktrees/` 外のセッションでは Edit/Write/NotebookEdit が `PreToolUse` hook で deny される
+- `.claude/worktrees/` 外のセッションでは Edit/Write/NotebookEdit が `PreToolUse` hook で deny される
 - 素 `claude` で起動した場合、編集したくなったら `ccw` で切り直すか、セッション中に worktree の作成を依頼する
 
 ## File Restrictions

--- a/docs/superpowers/specs/2026-04-18-ref-ccw-design.md
+++ b/docs/superpowers/specs/2026-04-18-ref-ccw-design.md
@@ -80,7 +80,7 @@ ccw() {
 
   local topic="${*:-（トピックはこれから相談する）}"
   local prompt
-  prompt="superpowers:using-git-worktrees スキルの Start フェーズを実行し、作成した worktree に移動してください。その worktree 内で superpowers:brainstorming スキルを起動し、次のトピックでブレストを始めてください: ${topic}"
+  prompt="このセッションは Claude Code の --worktree sandbox 内です。superpowers:brainstorming → superpowers:writing-plans → superpowers:executing-plans の順で進めてください。トピック: ${topic}"
 
   exec claude --permission-mode auto --worktree -- "$prompt"
 }
@@ -105,14 +105,14 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
 
 case "$cwd" in
-  */.worktrees/*|*/.worktrees)
+  */.claude/worktrees/*|*/.claude/worktrees)
     exit 0
     ;;
 esac
 
 case "$tool" in
   Edit|Write|NotebookEdit)
-    jq -n --arg reason "This session is not running inside a git worktree (.worktrees/*). Exit and relaunch with: ccw <topic>, or ask Claude to start a worktree before editing." '{
+    jq -n --arg reason "This session is not running inside a Claude Code worktree (.claude/worktrees/*). Exit and relaunch with: ccw <topic>." '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
@@ -128,7 +128,7 @@ esac
 
 注意点:
 
-- `.worktrees/` のみ対象（superpowers skill のデフォルト配置）
+- `.claude/worktrees/` のみ対象（Claude Code `--worktree` の sandbox 配置）
 - jq 依存（dotfiles の既存前提）
 - shebang `#!/usr/bin/env bash` + `set -euo pipefail` は dotfiles の規約準拠
 
@@ -180,7 +180,7 @@ esac
 ## Worktree Workflow
 
 - 実装を伴う作業では `ccw <topic>` で Claude Code を起動すること
-- `.worktrees/` 外のセッションでは Edit/Write/NotebookEdit が deny される（hook による保護）
+- `.claude/worktrees/` 外のセッションでは Edit/Write/NotebookEdit が deny される（hook による保護）
 - 素 `claude` で起動した場合、編集したくなったら `ccw` で切り直すか、セッション中に worktree の作成を依頼する
 ```
 
@@ -194,14 +194,14 @@ user $ ccw "ref-ccw ブレスト"
   └─ exec claude --permission-mode auto --worktree -- "…topic…"
        └─ Claude Code: worktree 作成 (origin/HEAD 基準)
        └─ Claude Code: worktree cwd でセッション開始 (auto mode)
-       └─ Claude: skill Start フェーズ → brainstorming
+       └─ Claude: brainstorming → writing-plans → executing-plans
 ```
 
 ### 素 claude での誤起動時
 
 ```text
 user $ claude  # repo root
-  └─ Claude Code: cwd = repo root (NOT .worktrees/*)
+  └─ Claude Code: cwd = repo root (NOT .claude/worktrees/*)
        └─ Claude: Edit を試行
             └─ PreToolUse → require-worktree.sh → deny
                  └─ Claude は救済メッセージを受け、ユーザーに ccw 再起動を促す or
@@ -258,5 +258,5 @@ user $ claude  # repo root
 
 - `claude --help` → `-w, --worktree [name]`, `--permission-mode auto`（v2.1.113 で確認）
 - Claude Code docs — Hooks reference の `PreToolUse.permissionDecision`
-- `superpowers:using-git-worktrees` skill（本 worktree 作成に使用）
+- Claude Code `-w, --worktree` フラグ（sandbox worktree を `.claude/worktrees/<auto-name>/` に自動作成）
 - 既存の `hooks.Stop` 実装（`src/.claude/settings.personal.json`）

--- a/scripts/tests/test-require-worktree.sh
+++ b/scripts/tests/test-require-worktree.sh
@@ -55,7 +55,7 @@ assert_deny() {
 
 # Case 1: cwd inside worktree + Edit → allow
 assert_allow "inside-worktree-edit" \
-  '{"cwd":"/Users/me/project/.worktrees/foo","tool_name":"Edit"}'
+  '{"cwd":"/Users/me/project/.claude/worktrees/foo","tool_name":"Edit"}'
 
 # Case 2: cwd outside worktree + Edit → deny
 assert_deny "outside-edit" \

--- a/src/.claude/hooks/require-worktree.sh
+++ b/src/.claude/hooks/require-worktree.sh
@@ -11,14 +11,14 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
 tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
 
 case "$cwd" in
-  */.worktrees/*|*/.worktrees)
+  */.claude/worktrees/*|*/.claude/worktrees)
     exit 0
     ;;
 esac
 
 case "$tool" in
   Edit|Write|NotebookEdit)
-    jq -n --arg reason "This session is not running inside a git worktree (.worktrees/*). Exit and relaunch with: ccw <topic>, or ask Claude to start a worktree before editing." '{
+    jq -n --arg reason "This session is not running inside a Claude Code worktree (.claude/worktrees/*). Exit and relaunch with: ccw <topic>." '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",

--- a/src/.shell_common
+++ b/src/.shell_common
@@ -93,9 +93,26 @@ if command -v git &> /dev/null; then
   alias gclean='git_cleanup_branches'
 
   # Claude Code を新規 worktree + auto permission mode で起動する
-  # Usage: ccw [トピック...]
+  # Usage: ccw [トピック...] | ccw -h | ccw --help
   # worktree 名は Claude Code が自動採番。origin/HEAD を毎回同期してから起動。
   ccw() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+      cat <<'EOF'
+ccw - Claude Code を新規 worktree sandbox + auto permission mode で起動
+
+Usage:
+  ccw [topic...]      指定トピックでブレストを開始
+  ccw                 トピックを後で相談する形で起動
+  ccw -h | --help     このヘルプを表示
+
+仕組み:
+  - claude --worktree が .claude/worktrees/<auto-name>/ に sandbox worktree を作成
+  - --permission-mode auto でツール承認をスキップ
+  - 起動前に origin/HEAD を同期 (git remote set-head origin -a)
+  - sandbox 外の Edit/Write/NotebookEdit は require-worktree.sh hook で deny
+EOF
+      return 0
+    fi
     if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       echo "ccw: not inside a git repository" >&2
       return 1
@@ -113,7 +130,7 @@ if command -v git &> /dev/null; then
 
     local topic="${*:-（トピックはこれから相談する）}"
     local prompt
-    prompt="superpowers:using-git-worktrees スキルの Start フェーズを実行し、作成した worktree に移動してください。その worktree 内で superpowers:brainstorming スキルを起動し、次のトピックでブレストを始めてください: ${topic}"
+    prompt="このセッションは Claude Code の --worktree sandbox 内です。superpowers:brainstorming → superpowers:writing-plans → superpowers:executing-plans の順で進めてください。トピック: ${topic}"
 
     exec claude --permission-mode auto --worktree -- "$prompt"
   }


### PR DESCRIPTION

## 📒 変更の概要

- `.gitignore` に `.claude/worktrees/` を追加しました。
- `AGENTS.md` と `docs/superpowers/specs/2026-04-18-ref-ccw-design.md` の内容を更新し、`ccw` コマンドが `.claude/worktrees/` 内で動作することを明示しました。
- `require-worktree.sh` スクリプトを修正し、作業ツリーのパスを `.claude/worktrees/` に変更しました。
- テストスクリプト `test-require-worktree.sh` を更新し、作業ディレクトリのパスを新しいものに合わせました。

## ⚒ 技術的詳細

- `ccw` コマンドのヘルプメッセージを改善し、使用方法を明確にしました。
- `require-worktree.sh` スクリプト内で、作業ディレクトリが `.claude/worktrees/` にあるかどうかを確認するロジックを追加しました。
- 編集ツール（Edit/Write/NotebookEdit）が許可される条件を `.claude/worktrees/` に限定しました。

## ⚠ 注意点

- 💡 `.claude/worktrees/` のみが対象となるため、他の作業ツリーでは動作しません。
- ⚠ jq に依存しているため、環境に jq がインストールされていることを確認してください。
- 🛠 shebang `#!/usr/bin/env bash` と `set -euo pipefail` は dotfiles の規約に従っています。