### PR TITLE
🧹 `.claude/settings.json` の重複項目を削除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,4 @@
 {
-  "env": {
-    "ENABLE_TOOL_SEARCH": "true"
-  },
-  "includeCoAuthoredBy": false,
-  "permissions": {
-    "defaultMode": "plan"
-  },
   "hooks": {
     "PostToolUse": [
       {
@@ -17,28 +10,9 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "afplay /System/Library/Sounds/Glass.aiff"
-          }
-        ]
-      }
     ]
   },
   "enabledPlugins": {
     "claude-api@anthropic-agent-skills": true
-  },
-  "extraKnownMarketplaces": {
-    "anthropic-agent-skills": {
-      "source": {
-        "source": "github",
-        "repo": "anthropics/skills"
-      }
-    }
-  },
-  "language": "日本語"
+  }
 }


### PR DESCRIPTION

このプルリクエストでは、`.claude/settings.json` ファイルから重複している項目を削除しました。具体的には、`personal` セクションと重複する設定を整理し、ファイルを簡素化しました。

## 📒 変更の概要

- 🔧 `.claude/settings.json` から以下の項目を削除しました:
  - `env` セクション
  - `permissions` セクション
  - `Stop` フック
  - `extraKnownMarketplaces` セクション

これにより、設定ファイルがよりシンプルになり、管理が容易になります。

## ⚒ 技術的詳細

- 🗂️ `hooks` セクションはそのまま残し、必要なフックのみを保持しました。
- 🔌 `enabledPlugins` セクションもそのまま維持されています。

## ⚠ 注意点

- ⚠️ この変更により、削除された設定が必要な場合は、再度追加する必要があります。特に、`env` や `permissions` に関連する設定が必要な場合は、注意してください。