### PR TITLE
✨ 新しいプラグイン「skill-matcher」の追加と設定変更

### DIFF
--- a/src/.claude/plugins/installed_plugins.personal.json
+++ b/src/.claude/plugins/installed_plugins.personal.json
@@ -86,6 +86,16 @@
         "installedAt": "2026-04-11T22:56:29.277Z",
         "lastUpdated": "2026-04-12T23:13:07.476Z"
       }
+    ],
+    "skill-matcher@tqer39-plugins": [
+      {
+        "scope": "user",
+        "installPath": "/Users/takeruooyama/.claude/plugins/cache/tqer39-plugins/skill-matcher/0.1.0",
+        "version": "0.1.0",
+        "installedAt": "2026-04-19T04:27:13.730Z",
+        "lastUpdated": "2026-04-19T04:27:13.730Z",
+        "gitCommitSha": "27774303d5e58f06e29fb376370c0080700d6167"
+      }
     ]
   }
 }

--- a/src/.claude/settings.personal.json
+++ b/src/.claude/settings.personal.json
@@ -24,7 +24,7 @@
       "Read(//Users/*/.ssh/*.pem)",
       "Read(//Users/*/.netrc)"
     ],
-    "defaultMode": "plan"
+    "defaultMode": "auto"
   },
   "hooks": {
     "PreToolUse": [
@@ -81,5 +81,6 @@
     }
   },
   "language": "日本語",
-  "effortLevel": "high"
+  "effortLevel": "high",
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION

## 📒 変更の概要

- 新しいプラグイン「skill-matcher」を追加しました。
- 設定のデフォルトモードを「plan」から「auto」に変更しました。
- パーミッションプロンプトをスキップするオプションを追加しました。

## ⚒ 技術的詳細

- `src/.claude/plugins/installed_plugins.personal.json` に「skill-matcher」プラグインの情報を追加しました。
- `src/.claude/settings.personal.json` でデフォルトモードを「auto」に変更し、パーミッションプロンプトをスキップするオプションを追加しました。

## ⚠ 注意点

- 💡 新しいプラグインの導入に伴い、動作確認を行うことをお勧めします。
- ⚠ 設定変更が他の機能に影響を与える可能性があるため、十分なテストを行ってください。