### PR TITLE
🔧 Lint設定の更新とpnpmワークスペースの追加

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,3 @@
+{
+  "ignores": ["node_modules/", "docs/superpowers/"]
+}

--- a/.textlintignore
+++ b/.textlintignore
@@ -6,5 +6,6 @@
 .textlintcache
 .yamllint.yml
 cspell.json
+docs/superpowers/**
 renovate.json
 tmp/

--- a/cspell.json
+++ b/cspell.json
@@ -8,7 +8,8 @@
     "**/.terraform.lock.hcl",
     "**/*.drawio.svg",
     "pnpm-lock.yaml",
-    "node_modules/**"
+    "node_modules/**",
+    "docs/superpowers/**"
   ],
   "dictionaryDefinitions": [
     {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://www.schemastore.org/pnpm-workspace.json
+allowBuilds:
+  '@biomejs/biome': false


### PR DESCRIPTION

## 📒 Summary of Changes

1. 📝 `docs/superpowers/` を lint 対象から除外しました。
   - 新しい設定ファイル `.markdownlint-cli2.jsonc` を追加し、`docs/superpowers/` を無視リストに追加しました。
   - `.textlintignore` にも `docs/superpowers/**` を追加しました。
   - `cspell.json` に `docs/superpowers/**` を追加し、スペルチェックの対象から除外しました。

2. 📦 `pnpm-workspace.yaml` を追加しました。
   - `allowBuilds` を明示的に設定し、`@biomejs/biome` のビルドを無効にしました。

## ⚒ Technical Details

- `.markdownlint-cli2.jsonc` ファイルは、MarkdownファイルのLinting設定を管理します。
- `.textlintignore` ファイルは、TextLintが無視するファイルやディレクトリを指定します。
- `cspell.json` は、スペルチェックの設定を行うファイルで、特定のディレクトリを無視するように設定されています。
- `pnpm-workspace.yaml` は、pnpmのワークスペース設定を行うファイルで、ビルドの許可設定を含んでいます。

## ⚠ Points of Caution

1. ⚠️ Lint対象から除外した `docs/superpowers/` ディレクトリ内のファイルは、Lintチェックが行われないため、手動での確認が必要です。
2. ⚠️ `pnpm-workspace.yaml` の設定変更により、特定のパッケージのビルドが無効になっているため、ビルドプロセスに影響を与える可能性があります。