### PR TITLE
✨ cmux 用の Karabiner ルールと dotfiles 取り込み

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,5 +13,16 @@
       "enabled": true,
       "trailingCommas": "none"
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": ["src/.config/cmux/settings.json"],
+      "json": {
+        "parser": {
+          "allowComments": true,
+          "allowTrailingCommas": true
+        }
+      }
+    }
+  ]
 }

--- a/config/platform-files.conf
+++ b/config/platform-files.conf
@@ -60,6 +60,9 @@ Microsoft.PowerShell_profile.ps1:~/Documents/WindowsPowerShell/Microsoft.PowerSh
 # macOS specific - Karabiner Elements (keyboard customization)
 .config/karabiner/karabiner.json:~/.config/karabiner/karabiner.json:macos
 
+# macOS specific - cmux terminal multiplexer
+.config/cmux/settings.json:~/.config/cmux/settings.json:macos
+
 # macOS specific - Raycast script commands
 .config/raycast/scripts/ghostty-new-window.sh:~/.config/raycast/scripts/ghostty-new-window.sh:macos
 

--- a/src/.config/cmux/settings.json
+++ b/src/.config/cmux/settings.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux-settings.schema.json",
+  "schemaVersion": 1,
+
+  // This file uses JSON with comments (JSONC).
+  // Uncomment and edit any setting to make it file-managed.
+  // Remove a setting to fall back to the value saved in Settings.
+  // cmux creates this template on launch when both settings file locations are missing.
+  // ~/.config/cmux/settings.json takes precedence over the Application Support fallback.
+
+  //   "app" : {
+  //     "appearance" : "system",
+  //     "appIcon" : "automatic",
+  //     "commandPaletteSearchesAllSurfaces" : false,
+  //     "focusPaneOnFirstClick" : false,
+  //     "keepWorkspaceOpenWhenClosingLastSurface" : false,
+  //     "language" : "system",
+  //     "minimalMode" : false,
+  //     "newWorkspacePlacement" : "afterCurrent",
+  //     "preferredEditor" : "",
+  //     "renameSelectsExistingName" : true,
+  //     "reorderOnNotification" : true,
+  //     "sendAnonymousTelemetry" : true,
+  //     "warnBeforeQuit" : true
+  //   },
+
+  //   "notifications" : {
+  //     "command" : "",
+  //     "customSoundFilePath" : "",
+  //     "dockBadge" : true,
+  //     "paneFlash" : true,
+  //     "showInMenuBar" : true,
+  //     "sound" : "default",
+  //     "unreadPaneRing" : true
+  //   },
+
+  //   "sidebar" : {
+  //     "branchLayout" : "vertical",
+  //     "hideAllDetails" : false,
+  //     "openPortLinksInCmuxBrowser" : true,
+  //     "openPullRequestLinksInCmuxBrowser" : true,
+  //     "showBranchDirectory" : true,
+  //     "showCustomMetadata" : true,
+  //     "showLog" : true,
+  //     "showNotificationMessage" : true,
+  //     "showPorts" : true,
+  //     "showProgress" : true,
+  //     "showPullRequests" : true,
+  //     "showSSH" : true
+  //   },
+
+  //   "workspaceColors" : {
+  //     "colors" : {
+  //       "Amber" : "#7D6608",
+  //       "Aqua" : "#0E6B8C",
+  //       "Blue" : "#1565C0",
+  //       "Brown" : "#7B3F00",
+  //       "Charcoal" : "#3E4B5E",
+  //       "Crimson" : "#922B21",
+  //       "Green" : "#196F3D",
+  //       "Indigo" : "#283593",
+  //       "Magenta" : "#AD1457",
+  //       "Navy" : "#1A5276",
+  //       "Olive" : "#4A5C18",
+  //       "Orange" : "#A04000",
+  //       "Purple" : "#6A1B9A",
+  //       "Red" : "#C0392B",
+  //       "Rose" : "#880E4F",
+  //       "Teal" : "#006B6B"
+  //     },
+  //     "indicatorStyle" : "leftRail",
+  //     "notificationBadgeColor" : null,
+  //     "selectionColor" : null
+  //   },
+
+  //   "sidebarAppearance" : {
+  //     "darkModeTintColor" : null,
+  //     "lightModeTintColor" : null,
+  //     "matchTerminalBackground" : false,
+  //     "tintColor" : "#000000",
+  //     "tintOpacity" : 0.17999999999999999
+  //   },
+
+  //   "automation" : {
+  //     "claudeBinaryPath" : "",
+  //     "claudeCodeIntegration" : true,
+  //     "portBase" : 9100,
+  //     "portRange" : 10,
+  //     "socketControlMode" : "cmuxOnly",
+  //     "socketPassword" : ""
+  //   },
+
+  //   "customCommands" : {
+  //     "trustedDirectories" : [
+  //
+  //     ]
+  //   },
+
+  //   "browser" : {
+  //     "defaultSearchEngine" : "google",
+  //     "hostsToOpenInEmbeddedBrowser" : [
+  //
+  //     ],
+  //     "insecureHttpHostsAllowedInEmbeddedBrowser" : [
+  //       "localhost",
+  //       "127.0.0.1",
+  //       "::1",
+  //       "0.0.0.0",
+  //       "*.localtest.me"
+  //     ],
+  //     "interceptTerminalOpenCommandInCmuxBrowser" : true,
+  //     "openTerminalLinksInCmuxBrowser" : true,
+  //     "reactGrabVersion" : "0.1.29",
+  //     "showImportHintOnBlankTabs" : true,
+  //     "showSearchSuggestions" : true,
+  //     "theme" : "system",
+  //     "urlsToAlwaysOpenExternally" : [
+  //
+  //     ]
+  //   },
+
+  "shortcuts": {
+    "bindings": {
+      //       "browserBack" : "cmd+[",
+      //       "browserForward" : "cmd+]",
+      //       "browserReload" : "cmd+r",
+      //       "browserZoomIn" : "cmd+=",
+      //       "browserZoomOut" : "cmd+-",
+      //       "browserZoomReset" : "cmd+0",
+      //       "closeOtherTabsInPane" : "cmd+opt+t",
+      //       "closeTab" : "cmd+w",
+      //       "closeWindow" : "cmd+ctrl+w",
+      //       "closeWorkspace" : "cmd+shift+w",
+      //       "commandPalette" : "cmd+shift+p",
+      //       "editWorkspaceDescription" : "cmd+shift+e",
+      //       "find" : "cmd+f",
+      //       "findNext" : "cmd+g",
+      //       "findPrevious" : "cmd+opt+g",
+      //       "focusBrowserAddressBar" : "cmd+l",
+      //       "focusDown" : "cmd+opt+↓",
+      //       "focusLeft" : "cmd+opt+←",
+      //       "focusRight" : "cmd+opt+→",
+      //       "focusUp" : "cmd+opt+↑",
+      //       "goToWorkspace" : "cmd+p",
+      //       "hideFind" : "cmd+shift+f",
+      //       "jumpToUnread" : "cmd+shift+u",
+      //       "newSurface" : "cmd+t",
+      //       "newTab" : "cmd+n",
+      //       "newWindow" : "cmd+shift+n",
+      //       "nextSidebarTab" : "cmd+ctrl+]",
+      //       "nextSurface" : "cmd+shift+]",
+      //       "openBrowser" : "cmd+shift+l",
+      //       "openFolder" : "cmd+o",
+      //       "openSettings" : "cmd+,",
+      //       "prevSidebarTab" : "cmd+ctrl+[",
+      //       "prevSurface" : "cmd+shift+[",
+      //       "quit" : "cmd+q",
+      //       "reloadConfiguration" : "cmd+shift+,",
+      "renameTab": "cmd+shift+r"
+      //       "renameWorkspace" : "cmd+shift+r",
+      //       "reopenClosedBrowserPanel" : "cmd+shift+t",
+      //       "selectSurfaceByNumber" : "ctrl+1",
+      //       "selectWorkspaceByNumber" : "cmd+1",
+      //       "sendFeedback" : "cmd+opt+f",
+      //       "showBrowserJavaScriptConsole" : "cmd+opt+c",
+      //       "showNotifications" : "cmd+i",
+      //       "splitBrowserDown" : "cmd+shift+opt+d",
+      //       "splitBrowserRight" : "cmd+opt+d",
+      //       "splitDown" : "cmd+shift+d",
+      //       "splitRight" : "cmd+d",
+      //       "toggleBrowserDeveloperTools" : "cmd+opt+i",
+      //       "toggleFullScreen" : "cmd+ctrl+f",
+      //       "toggleReactGrab" : "cmd+shift+g",
+      //       "toggleSidebar" : "cmd+b",
+      //       "toggleSplitZoom" : "cmd+shift+\r",
+      //       "toggleTerminalCopyMode" : "cmd+shift+m",
+      //       "triggerFlash" : "cmd+shift+h",
+      //       "useSelectionForFind" : "cmd+e"
+    }
+    //     "showModifierHoldHints" : true
+  }
+}

--- a/src/.config/karabiner/karabiner.json
+++ b/src/.config/karabiner/karabiner.json
@@ -1191,6 +1191,30 @@
                 "type": "basic"
               }
             ]
+          },
+          {
+            "description": "cmux: コマンドの履歴表示(cmd+r)",
+            "manipulators": [
+              {
+                "conditions": [
+                  {
+                    "bundle_identifiers": ["^com\\.cmuxterm\\.app$"],
+                    "type": "frontmost_application_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "r",
+                  "modifiers": { "mandatory": ["command"] }
+                },
+                "to": [
+                  {
+                    "key_code": "r",
+                    "modifiers": ["control"]
+                  }
+                ],
+                "type": "basic"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION

## 📒 変更の概要

- 🆕 `src/.config/cmux/settings.json` ファイルを新規作成し、cmux の設定を管理するためのテンプレートを追加しました。
- 🔧 `biome.json` に cmux の設定ファイルをオーバーライドするための設定を追加しました。
- 🖥️ `config/platform-files.conf` に cmux の設定ファイルのパスを追加しました。
- ⌨️ `src/.config/karabiner/karabiner.json` に cmux 用のコマンド履歴表示のショートカットを追加しました。

## ⚒ 技術的詳細

- `biome.json` に以下のオーバーライド設定を追加しました:
  ```json
  "overrides": [
    {
      "include": ["src/.config/cmux/settings.json"],
      "json": {
        "parser": {
          "allowComments": true,
          "allowTrailingCommas": true
        }
      }
    }
  ]
  ```
- `src/.config/cmux/settings.json` には、cmux の設定を管理するための詳細なコメント付きのテンプレートが含まれています。これにより、ユーザーは必要に応じて設定を変更できます。

## ⚠ 注意点

- ⚠️ `karabiner.json` に追加されたショートカットは、cmux が前面にある場合にのみ機能します。これにより、他のアプリケーションでのショートカットとの競合を避けることができます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cmux terminal multiplexer configuration support with preset keyboard shortcuts for tab management operations
  * Updated keyboard input remapping to optimize control key behavior within terminal applications
  * Enhanced configuration file handling to support JSON comments and trailing commas for improved readability and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->