### PR TITLE
🚀 GitHub ActionsのCI修正とcspellの更新

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -18,6 +18,7 @@ chdir
 checkwinsize
 chpwd
 chsh
+cmux
 codezombiech
 Consolas
 Cowork

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -109,6 +109,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     env:
       DOTFILES_DIR: ${{ github.workspace }}
+      # mise が GitHub API へ認証付きでアクセスし rate limit を回避する
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # GitHub Actions ランナーで node の GPG 公開鍵取得が失敗するため検証をスキップ
+      MISE_NODE_VERIFY: 'false'
 
     steps:
       - name: Checkout
@@ -175,6 +179,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOTFILES_DIR: ${{ github.workspace }}
+      # mise が GitHub API へ認証付きでアクセスし rate limit を回避する
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # GitHub Actions ランナーで node の GPG 公開鍵取得が失敗するため検証をスキップ
+      MISE_NODE_VERIFY: 'false'
 
     steps:
       - name: Checkout
@@ -302,6 +310,10 @@ jobs:
     runs-on: windows-latest
     env:
       DOTFILES_DIR: ${{ github.workspace }}
+      # mise が GitHub API へ認証付きでアクセスし rate limit を回避する
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # GitHub Actions ランナーで node の GPG 公開鍵取得が失敗するため検証をスキップ
+      MISE_NODE_VERIFY: 'false'
 
     steps:
       - name: Checkout


### PR DESCRIPTION

## 📒 変更の概要

- `cspell`に`cmux`を追加しました。
- GitHub ActionsのCI設定を修正し、GitHub APIのレート制限を回避するためのトークンを追加しました。
- Node.jsのGPG検証エラーを回避するために、検証をスキップする設定を追加しました。

## ⚒ 技術的詳細

- `cspell`の設定ファイルである`.cspell/project-words.txt`に`cmux`を追加しました。これにより、`cmux`がスペルチェックの対象に含まれるようになります。
  
- `.github/workflows/test-install.yml`ファイルに以下の環境変数を追加しました：
  - `GITHUB_TOKEN`: GitHub APIへの認証付きアクセスを可能にし、レート制限を回避します。
  - `MISE_NODE_VERIFY`: Node.jsのGPG公開鍵取得が失敗する場合に、検証をスキップするためのフラグです。

## ⚠ 注意点

- 💡 `GITHUB_TOKEN`は、GitHubのシークレットとして設定されている必要があります。
- ⚠ `MISE_NODE_VERIFY`を`false`に設定することで、セキュリティ上のリスクが生じる可能性があるため、使用する際は注意が必要です。