### PR TITLE
GPG 検証の有効化とワークフローの修正

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -73,6 +73,7 @@ hackgen
 hammerspoon
 helperselector
 histappend
+hkps
 idempotently
 ignoredups
 ignorespace
@@ -86,6 +87,8 @@ keymap
 keymaps
 Keypirinha
 keyrings
+keyserver
+keyservers
 LASTEXITCODE
 lefthook
 lesspipe
@@ -116,6 +119,7 @@ O'oyama
 octocat
 oneline
 ooyama
+openpgp
 OPENROUTER
 orbstack
 pcra

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -101,8 +101,7 @@ jobs:
   # ------------------------------------------------------------------------------
   test-unix-full:
     name: Full - ${{ matrix.os }}
-    # NOTE: head_ref 条件は PR 検証用の一時的な開放。issue #403 task 2 の動作確認後に削除する
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'fix/test-install-mise-node-gpg'
+    if: github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -177,8 +176,7 @@ jobs:
   # ------------------------------------------------------------------------------
   test-unix-server:
     name: Server - ubuntu-latest
-    # NOTE: head_ref 条件は PR 検証用の一時的な開放。issue #403 task 2 の動作確認後に削除する
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'fix/test-install-mise-node-gpg'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       DOTFILES_DIR: ${{ github.workspace }}
@@ -310,8 +308,7 @@ jobs:
   # ------------------------------------------------------------------------------
   test-windows-full:
     name: Full - Windows
-    # NOTE: head_ref 条件は PR 検証用の一時的な開放。issue #403 task 2 の動作確認後に削除する
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'fix/test-install-mise-node-gpg'
+    if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
     env:
       DOTFILES_DIR: ${{ github.workspace }}

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -101,7 +101,8 @@ jobs:
   # ------------------------------------------------------------------------------
   test-unix-full:
     name: Full - ${{ matrix.os }}
-    if: github.ref == 'refs/heads/main'
+    # NOTE: head_ref 条件は PR 検証用の一時的な開放。issue #403 task 2 の動作確認後に削除する
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'fix/test-install-mise-node-gpg'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -111,8 +112,6 @@ jobs:
       DOTFILES_DIR: ${{ github.workspace }}
       # mise が GitHub API へ認証付きでアクセスし rate limit を回避する
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # GitHub Actions ランナーで node の GPG 公開鍵取得が失敗するため検証をスキップ
-      MISE_NODE_VERIFY: 'false'
 
     steps:
       - name: Checkout
@@ -137,6 +136,9 @@ jobs:
           key: ${{ runner.os }}-apt-${{ hashFiles('config/packages/apt-packages.txt') }}
           restore-keys: |
             ${{ runner.os }}-apt-
+
+      - name: Import Node.js release signing keys
+        run: bash scripts/ci/import-node-release-keys.sh
 
       - name: Test full install
         run: |
@@ -175,14 +177,13 @@ jobs:
   # ------------------------------------------------------------------------------
   test-unix-server:
     name: Server - ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # NOTE: head_ref 条件は PR 検証用の一時的な開放。issue #403 task 2 の動作確認後に削除する
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'fix/test-install-mise-node-gpg'
     runs-on: ubuntu-latest
     env:
       DOTFILES_DIR: ${{ github.workspace }}
       # mise が GitHub API へ認証付きでアクセスし rate limit を回避する
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # GitHub Actions ランナーで node の GPG 公開鍵取得が失敗するため検証をスキップ
-      MISE_NODE_VERIFY: 'false'
 
     steps:
       - name: Checkout
@@ -195,6 +196,9 @@ jobs:
           key: ${{ runner.os }}-apt-server-${{ hashFiles('config/packages/apt-packages.txt') }}
           restore-keys: |
             ${{ runner.os }}-apt-server-
+
+      - name: Import Node.js release signing keys
+        run: bash scripts/ci/import-node-release-keys.sh
 
       - name: Test server mode install
         run: |
@@ -306,14 +310,13 @@ jobs:
   # ------------------------------------------------------------------------------
   test-windows-full:
     name: Full - Windows
-    if: github.ref == 'refs/heads/main'
+    # NOTE: head_ref 条件は PR 検証用の一時的な開放。issue #403 task 2 の動作確認後に削除する
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'fix/test-install-mise-node-gpg'
     runs-on: windows-latest
     env:
       DOTFILES_DIR: ${{ github.workspace }}
       # mise が GitHub API へ認証付きでアクセスし rate limit を回避する
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # GitHub Actions ランナーで node の GPG 公開鍵取得が失敗するため検証をスキップ
-      MISE_NODE_VERIFY: 'false'
 
     steps:
       - name: Checkout
@@ -326,6 +329,10 @@ jobs:
           key: windows-scoop-${{ hashFiles('install.ps1') }}
           restore-keys: |
             windows-scoop-
+
+      - name: Import Node.js release signing keys
+        shell: bash
+        run: bash scripts/ci/import-node-release-keys.sh
 
       - name: Test full install
         shell: pwsh

--- a/scripts/ci/import-node-release-keys.sh
+++ b/scripts/ci/import-node-release-keys.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Node.js リリース署名鍵を GnuPG キーリングへ pre-import する。
+# mise が node をインストールする際に行う tarball の GPG 検証で利用される。
+# 参考: https://github.com/nodejs/release-keys
+set -euo pipefail
+
+# 現行 / 直近の node リリース署名者の long key id。
+# release-keys リポジトリと同期して更新する。
+keys=(
+  4ED778F539E3634C779C87C6D7062848A1AB005C
+  141F07595B7B3FFE74309A937405533BE57C7D57
+  74F12602B6F1C4E913FAA37AD3A89613643B6201
+  DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7
+  CC68F5A3106FF448322E48ED27F5E38D5B0A215F
+  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600
+  890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4
+  C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C
+  108F52B48DB57BB0CC439B2997B01419BD92F80A
+  A363A499291CBBC940DD62E41F10027AF002F8B0
+)
+
+# CI ランナーの DNS / firewall 事情に左右されないよう複数 keyserver を順に試す。
+keyservers=(
+  hkps://keys.openpgp.org
+  hkps://keyserver.ubuntu.com
+  hkp://pgp.mit.edu
+)
+
+failed=()
+for key in "${keys[@]}"; do
+  imported=0
+  for ks in "${keyservers[@]}"; do
+    if gpg --batch --keyserver "$ks" --recv-keys "$key" >/dev/null 2>&1; then
+      echo "imported: $key (from $ks)"
+      imported=1
+      break
+    fi
+  done
+  if [ "$imported" -eq 0 ]; then
+    echo "failed: $key (all keyservers exhausted)" >&2
+    failed+=("$key")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "ERROR: ${#failed[@]} 鍵のインポートに失敗しました" >&2
+  printf '  - %s\n' "${failed[@]}" >&2
+  exit 1
+fi
+
+echo "全 ${#keys[@]} 鍵のインポートに成功しました"


### PR DESCRIPTION

## 📒 Summary of Changes

- 🔄 `test-install.yml` から一時的な PR 検証用の `if` 条件を削除しました。
- 📜 GPG キーサーバー関連の単語を辞書に追加しました。
- 🔐 `test-install.yml` において、Node.js の GPG 検証を有効化しました。
- 🛠 新しいスクリプト `import-node-release-keys.sh` を追加し、Node.js リリース署名鍵を GnuPG キーリングにインポートする処理を実装しました。

## ⚒ Technical Details

- 🔧 `test-install.yml` の `if` 条件を修正し、PR 検証用の一時的な条件を削除しました。これにより、メインブランチへのプッシュ時のみジョブが実行されるようになります。
- 🗝 新たに追加されたスクリプト `import-node-release-keys.sh` は、Node.js のリリース署名鍵を複数の GPG キーサーバーからインポートするためのものです。このスクリプトは、CI ランナーの DNS やファイアウォールの制約に影響されないように設計されています。

```mermaid
graph TD;
    A[Node.js リリース署名鍵] --> B[インポート処理];
    B --> C{成功};
    C -->|はい| D[全鍵のインポート成功];
    C -->|いいえ| E[インポート失敗];
```

## ⚠ Points of Caution

- ⚠ `test-install.yml` の変更により、PR 検証用の条件が削除されたため、今後の PR ではメインブランチへのプッシュ時のみテストが実行されることに注意してください。
- ⚠ 新しいスクリプト `import-node-release-keys.sh` の実行には、GPG キーサーバーへのアクセスが必要です。ネットワーク環境によっては、鍵のインポートに失敗する可能性があります。