### PR TITLE
🐛 Windowsでのgit stderr警告による異常終了の修正

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -49,6 +49,9 @@ param(
 # Configuration
 # ------------------------------------------------------------------------------
 $ErrorActionPreference = "Stop"
+# PowerShell 7.3+ では既定で native command の stderr が terminating error 化する。
+# git の "LF will be replaced by CRLF" 等の警告で catch が暴発するため明示的に無効化する。
+$PSNativeCommandUseErrorActionPreference = $false
 $DotfilesRepo = "https://github.com/tqer39/dotfiles.git"
 $DotfilesBranch = "main"
 $DotfilesDir = if ($env:DOTFILES_DIR) { $env:DOTFILES_DIR } else { Join-Path $env:USERPROFILE ".dotfiles" }


### PR DESCRIPTION

## 📒 変更の概要

- `install.ps1`ファイルにおいて、Windows環境でのgitのstderr警告が原因でスクリプトが異常終了する問題を修正しました。この修正により、"LF will be replaced by CRLF"などの警告が発生してもスクリプトが正常に動作するようになります。

## ⚒ 技術的詳細

- `$PSNativeCommandUseErrorActionPreference`を`$false`に設定することで、PowerShell 7.3以降のデフォルトの動作を変更しました。これにより、ネイティブコマンドのstderrが終了コードを引き起こすことを防ぎます。

## ⚠ 注意点

- 💡 この変更は、PowerShellのバージョンに依存しています。PowerShell 7.3以上での動作を確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installer script reliability by preventing git warnings from being incorrectly treated as errors during the installation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tqer39/dotfiles/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->