### PR TITLE
🧹 `.gitattributes` 導入による CI の改善

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -252,6 +252,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Verify line endings honor .gitattributes
+        shell: pwsh
+        run: |
+          Write-Host "=== Verifying line endings ==="
+          # .gitattributes により .ps1 は CRLF で checkout される想定
+          $bytes = [System.IO.File]::ReadAllBytes("install.ps1")
+          $hasCRLF = $false
+          for ($i = 0; $i -lt $bytes.Length - 1; $i++) {
+            if ($bytes[$i] -eq 0x0D -and $bytes[$i + 1] -eq 0x0A) {
+              $hasCRLF = $true
+              break
+            }
+          }
+          if ($hasCRLF) {
+            Write-Host "OK: install.ps1 is checked out as CRLF (matches .gitattributes)"
+          } else {
+            Write-Host "ERROR: install.ps1 is not CRLF - .gitattributes may be missing or ineffective"
+            exit 1
+          }
+
+      - name: Verify no pending line-ending diffs under autocrlf=true
+        shell: pwsh
+        run: |
+          Write-Host "=== Simulating Windows default core.autocrlf=true ==="
+          git config --global core.autocrlf true
+          # renormalize していない状態でも、.gitattributes により working tree は安定する想定
+          $status = git status --porcelain
+          if ($status) {
+            Write-Host "ERROR: unexpected working-tree diffs under autocrlf=true:"
+            Write-Host $status
+            exit 1
+          }
+          Write-Host "OK: no spurious diffs under autocrlf=true"
+
       - name: Test dry-run mode
         shell: pwsh
         run: |

--- a/install.ps1
+++ b/install.ps1
@@ -49,9 +49,6 @@ param(
 # Configuration
 # ------------------------------------------------------------------------------
 $ErrorActionPreference = "Stop"
-# PowerShell 7.3+ では既定で native command の stderr が terminating error 化する。
-# git の "LF will be replaced by CRLF" 等の警告で catch が暴発するため明示的に無効化する。
-$PSNativeCommandUseErrorActionPreference = $false
 $DotfilesRepo = "https://github.com/tqer39/dotfiles.git"
 $DotfilesBranch = "main"
 $DotfilesDir = if ($env:DOTFILES_DIR) { $env:DOTFILES_DIR } else { Join-Path $env:USERPROFILE ".dotfiles" }


### PR DESCRIPTION

## 📒 変更の概要

- `.gitattributes` を導入し、不要になった抑止策を削除しました。
- CI のワークフローにおいて、`install.ps1` の行末が正しく設定されているかを検証するステップを追加しました。

## ⚒ 技術的詳細

- `.github/workflows/test-install.yml` に以下の検証ステップを追加しました：
  - `install.ps1` が CRLF でチェックアウトされているかを確認するスクリプトを追加。
  - `core.autocrlf=true` の設定下で、予期しないワーキングツリーの差分がないかを確認するスクリプトを追加。

- `install.ps1` からは、PowerShell 7.3+ におけるエラーハンドリングのための設定を削除しました。

## ⚠ 注意点

- 💡 `.gitattributes` の設定が正しく機能していない場合、行末の形式が期待通りでない可能性があります。CI の結果を確認し、エラーが発生した場合は設定を見直してください。

Closes #410