### PR TITLE
🚀 CodexスキルのリンクをClaude Codeスキルに追加

### DIFF
--- a/scripts/dotfiles.sh
+++ b/scripts/dotfiles.sh
@@ -18,6 +18,8 @@ source "${SCRIPT_DIR}/lib/utils.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/lib/symlink.sh"
 # shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/skills.sh"
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/lib/doctor.sh"
 
 # Install dotfiles by creating symlinks
@@ -113,23 +115,6 @@ install_claude_settings() {
   create_symlink "$config_src" "${HOME}/.claude/plugins/config.json"
 }
 
-# List Claude Code skill directories managed by this repository.
-list_claude_skill_dirs() {
-  local skill_root="${DOTFILES_DIR}/.claude/skills"
-
-  if [[ -d "$skill_root" ]]; then
-    find "$skill_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print |
-      while IFS= read -r skill_file; do
-        dirname "$skill_file"
-      done
-  fi
-
-  find "${DOTFILES_DIR}/src" -path "*/.claude/skills/*/SKILL.md" -print |
-    while IFS= read -r skill_file; do
-      dirname "$skill_file"
-    done
-}
-
 # Install Codex skills by linking Claude Code skills into ~/.codex/skills.
 install_codex_skills() {
   log_info "Installing Codex skills from Claude Code skills"
@@ -141,8 +126,9 @@ install_codex_skills() {
     local skill_name
     skill_name=$(basename "$skill_dir")
 
-    create_symlink "$skill_dir" "${HOME}/.codex/skills/${skill_name}"
-    installed_count=$((installed_count + 1))
+    if create_symlink "$skill_dir" "${HOME}/.codex/skills/${skill_name}"; then
+      installed_count=$((installed_count + 1))
+    fi
   done < <(list_claude_skill_dirs)
 
   log_info "Codex skills installed: $installed_count"

--- a/scripts/dotfiles.sh
+++ b/scripts/dotfiles.sh
@@ -84,6 +84,9 @@ install_dotfiles() {
   # Install Claude Code settings
   install_claude_settings
 
+  # Install Codex skills from Claude Code skills
+  install_codex_skills
+
   echo ""
   log_success "Dotfiles installation complete!"
   log_info "Installed: $installed_count, Skipped: $skipped_count"
@@ -110,6 +113,41 @@ install_claude_settings() {
   create_symlink "$config_src" "${HOME}/.claude/plugins/config.json"
 }
 
+# List Claude Code skill directories managed by this repository.
+list_claude_skill_dirs() {
+  local skill_root="${DOTFILES_DIR}/.claude/skills"
+
+  if [[ -d "$skill_root" ]]; then
+    find "$skill_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print |
+      while IFS= read -r skill_file; do
+        dirname "$skill_file"
+      done
+  fi
+
+  find "${DOTFILES_DIR}/src" -path "*/.claude/skills/*/SKILL.md" -print |
+    while IFS= read -r skill_file; do
+      dirname "$skill_file"
+    done
+}
+
+# Install Codex skills by linking Claude Code skills into ~/.codex/skills.
+install_codex_skills() {
+  log_info "Installing Codex skills from Claude Code skills"
+
+  local installed_count=0
+  local skill_dir
+
+  while IFS= read -r skill_dir; do
+    local skill_name
+    skill_name=$(basename "$skill_dir")
+
+    create_symlink "$skill_dir" "${HOME}/.codex/skills/${skill_name}"
+    installed_count=$((installed_count + 1))
+  done < <(list_claude_skill_dirs)
+
+  log_info "Codex skills installed: $installed_count"
+}
+
 # Uninstall Claude Code settings symlinks
 uninstall_claude_settings() {
   local src_dir="${DOTFILES_DIR}/src/.claude"
@@ -132,6 +170,27 @@ uninstall_claude_settings() {
       fi
     fi
   done
+}
+
+# Uninstall Codex skill symlinks managed by this repository.
+uninstall_codex_skills() {
+  log_info "Uninstalling Codex skills"
+
+  local skill_dir
+
+  while IFS= read -r skill_dir; do
+    local skill_name target
+    skill_name=$(basename "$skill_dir")
+    target="${HOME}/.codex/skills/${skill_name}"
+
+    if [[ -L "$target" ]]; then
+      local link_target
+      link_target=$(readlink "$target")
+      if [[ "$link_target" == "${DOTFILES_DIR}/"* ]]; then
+        remove_symlink "$target" true
+      fi
+    fi
+  done < <(list_claude_skill_dirs)
 }
 
 # Show status of Claude Code settings symlinks
@@ -176,6 +235,44 @@ status_claude_settings() {
 
     printf "%-40s %-10s %s\n" ".claude/${target_name}" "$status" "$details"
   done
+}
+
+# Show status of Codex skill symlinks.
+status_codex_skills() {
+  echo ""
+  printf "%-40s %-10s %s\n" "CODEX SKILLS" "STATUS" "DETAILS"
+  printf "%-40s %-10s %s\n" "------------" "------" "-------"
+
+  local skill_dir
+
+  while IFS= read -r skill_dir; do
+    local skill_name full_dest status details
+    skill_name=$(basename "$skill_dir")
+    full_dest="${HOME}/.codex/skills/${skill_name}"
+
+    if [[ ! -f "${skill_dir}/SKILL.md" ]]; then
+      status="MISSING"
+      details="Source not found"
+    elif [[ -L "$full_dest" ]]; then
+      local target
+      target=$(readlink "$full_dest")
+      if [[ "$target" == "$skill_dir" ]]; then
+        status="OK"
+        details="Linked correctly"
+      else
+        status="WRONG"
+        details="Links to: $target"
+      fi
+    elif [[ -e "$full_dest" ]]; then
+      status="EXISTS"
+      details="Not a symlink"
+    else
+      status="NONE"
+      details="Not installed"
+    fi
+
+    printf "%-40s %-10s %s\n" ".codex/skills/${skill_name}" "$status" "$details"
+  done < <(list_claude_skill_dirs)
 }
 
 # Uninstall dotfiles by removing symlinks
@@ -225,6 +322,9 @@ uninstall_dotfiles() {
 
   # Uninstall Claude Code settings
   uninstall_claude_settings
+
+  # Uninstall Codex skills
+  uninstall_codex_skills
 
   echo ""
   log_success "Dotfiles uninstallation complete!"
@@ -291,6 +391,9 @@ status_dotfiles() {
 
   # Show Claude Code settings status
   status_claude_settings
+
+  # Show Codex skills status
+  status_codex_skills
 }
 
 # Main entry point when script is run directly

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -221,22 +221,6 @@ doctor_check_claude_settings() {
   done
 }
 
-doctor_list_claude_skill_dirs() {
-  local skill_root="${DOTFILES_DIR}/.claude/skills"
-
-  if [[ -d "$skill_root" ]]; then
-    find "$skill_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print |
-      while IFS= read -r skill_file; do
-        dirname "$skill_file"
-      done
-  fi
-
-  find "${DOTFILES_DIR}/src" -path "*/.claude/skills/*/SKILL.md" -print |
-    while IFS= read -r skill_file; do
-      dirname "$skill_file"
-    done
-}
-
 doctor_check_codex_skills() {
   _doctor_section_header "Codex Skills"
 
@@ -262,7 +246,7 @@ doctor_check_codex_skills() {
     else
       doctor_check_warn ".codex/skills/${skill_name}" "Not installed"
     fi
-  done < <(doctor_list_claude_skill_dirs)
+  done < <(list_claude_skill_dirs)
 }
 
 doctor_check_mise_npm_tools() {

--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -221,6 +221,50 @@ doctor_check_claude_settings() {
   done
 }
 
+doctor_list_claude_skill_dirs() {
+  local skill_root="${DOTFILES_DIR}/.claude/skills"
+
+  if [[ -d "$skill_root" ]]; then
+    find "$skill_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print |
+      while IFS= read -r skill_file; do
+        dirname "$skill_file"
+      done
+  fi
+
+  find "${DOTFILES_DIR}/src" -path "*/.claude/skills/*/SKILL.md" -print |
+    while IFS= read -r skill_file; do
+      dirname "$skill_file"
+    done
+}
+
+doctor_check_codex_skills() {
+  _doctor_section_header "Codex Skills"
+
+  local skill_dir
+
+  while IFS= read -r skill_dir; do
+    local skill_name full_dest
+    skill_name=$(basename "$skill_dir")
+    full_dest="${HOME}/.codex/skills/${skill_name}"
+
+    if [[ ! -f "${skill_dir}/SKILL.md" ]]; then
+      doctor_check_fail ".codex/skills/${skill_name}" "Source not found"
+    elif [[ -L "$full_dest" ]]; then
+      local target
+      target=$(readlink "$full_dest")
+      if [[ "$target" == "$skill_dir" ]]; then
+        doctor_check_ok ".codex/skills/${skill_name}" "Linked correctly"
+      else
+        doctor_check_fail ".codex/skills/${skill_name}" "Wrong target: $target"
+      fi
+    elif [[ -e "$full_dest" ]]; then
+      doctor_check_fail ".codex/skills/${skill_name}" "Exists but not a symlink"
+    else
+      doctor_check_warn ".codex/skills/${skill_name}" "Not installed"
+    fi
+  done < <(doctor_list_claude_skill_dirs)
+}
+
 doctor_check_mise_npm_tools() {
   local mise_config="${DOTFILES_DIR}/src/.config/mise/config.toml"
 
@@ -353,6 +397,7 @@ run_doctor() {
   doctor_check_runtimes
   doctor_check_vscode
   doctor_check_claude_settings
+  doctor_check_codex_skills
 
   # Print summary
   doctor_print_summary

--- a/scripts/lib/skills.sh
+++ b/scripts/lib/skills.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# skills.sh - Skill discovery utilities
+# ------------------------------------------------------------------------------
+
+# Include guard to prevent multiple sourcing
+if [[ -n "${_SKILLS_SH_LOADED:-}" ]]; then
+  return 0
+fi
+readonly _SKILLS_SH_LOADED=1
+
+# List Claude Code skill directories managed by this repository.
+list_claude_skill_dirs() {
+  local skill_root="${DOTFILES_DIR}/.claude/skills"
+
+  if [[ -d "$skill_root" ]]; then
+    find "$skill_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print |
+      while IFS= read -r skill_file; do
+        dirname "$skill_file"
+      done
+  fi
+
+  find "${DOTFILES_DIR}/src" -path "*/.claude/skills/*/SKILL.md" -print |
+    while IFS= read -r skill_file; do
+      dirname "$skill_file"
+    done
+}


### PR DESCRIPTION

## 📒 変更の概要

1. ✨ `scripts/dotfiles.sh`にCodexスキルをインストールする機能を追加しました。
2. 🆕 新しいファイル`scripts/lib/skills.sh`を作成し、Claude Codeスキルのディレクトリをリストするユーティリティ関数を追加しました。
3. 🔧 `install_codex_skills`関数を実装し、Claude Codeスキルを`~/.codex/skills`にリンクする処理を追加しました。
4. 🛠 `uninstall_codex_skills`関数を実装し、インストールされたCodexスキルのリンクを削除する機能を追加しました。
5. 📊 `status_codex_skills`関数を追加し、Codexスキルの状態を表示する機能を実装しました。
6. 🔍 `doctor_check_codex_skills`関数を追加し、Codexスキルのチェック機能を実装しました。

## ⚒ 技術的詳細

1. 📁 `scripts/dotfiles.sh`内で、`install_codex_skills`関数を呼び出して、Codexスキルをインストールする処理を追加しました。
2. 📜 `scripts/lib/skills.sh`に新しい関数`list_claude_skill_dirs`を実装し、Claude Codeスキルのディレクトリをリストする機能を提供します。
3. 🔗 `install_codex_skills`関数では、Claude Codeスキルのディレクトリをループし、各スキルを`~/.codex/skills`にシンボリックリンクとして作成します。
4. ❌ `uninstall_codex_skills`関数では、既存のリンクを確認し、正しいリンク先であれば削除します。
5. 📊 `status_codex_skills`関数は、各Codexスキルの状態を表示し、リンクの正確性や存在を確認します。
6. 🩺 `doctor_check_codex_skills`関数は、スキルの状態をチェックし、問題があれば警告を表示します。

## ⚠ 注意点

1. ⚠️ 新しい機能が追加されたため、既存のスクリプトとの互換性に注意してください。
2. 🔄 シンボリックリンクの作成や削除に関する操作は、適切な権限が必要です。