### PR TITLE
🔧 PowerShell 5.1でのgit stderrに対する耐性を向上

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -188,6 +188,13 @@ function Update-Repository {
     # Helper function to stash local changes and pull
     Push-Location $DotfilesDir
     try {
+        # git writes informational messages (e.g. "CRLF will be replaced by LF")
+        # to stderr. Under $ErrorActionPreference = "Stop", PowerShell 5.1 wraps a
+        # native command's stderr in NativeCommandError records and promotes them to
+        # terminating errors even when the command's exit code is 0. Relax the
+        # preference locally and rely on $LASTEXITCODE to detect real failures.
+        $ErrorActionPreference = "Continue"
+
         # Check for uncommitted changes (tracked files)
         git diff --quiet 2>$null
         $hasDiff = $LASTEXITCODE -ne 0
@@ -251,7 +258,15 @@ function Install-Repository {
         if ($DryRun) {
             Write-Info "[DRY-RUN] Would run: git clone $DotfilesRepo $DotfilesDir"
         } else {
+            # See Update-Repository: git clone reports progress on stderr, which
+            # $ErrorActionPreference = "Stop" would turn into a terminating error in
+            # PowerShell 5.1. Relax locally and check the exit code instead.
+            $ErrorActionPreference = "Continue"
             git clone --branch $DotfilesBranch $DotfilesRepo $DotfilesDir
+            if ($LASTEXITCODE -ne 0) {
+                Write-Err "Failed to clone dotfiles repository (exit code $LASTEXITCODE)"
+                exit 1
+            }
             Write-Success "Cloned dotfiles repository"
         }
     }


### PR DESCRIPTION

## 📒 Summary of Changes

- 🛠️ PowerShell 5.1でのgitのstderrメッセージを無視するように修正。
- 🔄 エラープリファレンスをローカルで緩和し、実際の失敗を検出。

## ⚒ Technical Details

- 📜 `install.ps1`内の`Update-Repository`および`Install-Repository`関数で、`$ErrorActionPreference`を`"Continue"`に設定。
- 🔍 `git diff`および`git clone`の実行時に、エラーメッセージを無視し、`$LASTEXITCODE`で実際のエラーを確認。

## ⚠ Points of Caution

- ⚠️ PowerShell 5.1の動作に依存しているため、他のバージョンでの動作確認が必要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue affecting PowerShell 5.1 where repository installation and updates could fail due to improper error handling during git operations. Errors are now correctly detected and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->