### PR TITLE
🛠 Claude設定の文言修正と1Mコンテキストの有効化

### DIFF
--- a/docs/adr/0006-claude-code-settings-management.md
+++ b/docs/adr/0006-claude-code-settings-management.md
@@ -162,6 +162,6 @@ src/.claude.json          # Claude Code のグローバルメタデータ
 
 ### 注意事項
 
-- `allow` リストの追加は慎重に行う。`gh api:*` や `cat:*` のようなワイルドカードは機密ファイルへのアクセスや破壊的 API 呼び出しを許可してしまう
-- `settings.local.json` は `.gitignore` 済みのため、machine-specific な設定や一時的な権限緩和はそちらで行う
+- `allow` リストの追加は慎重に実施する。`gh api:*` や `cat:*` のようなワイルドカードは機密ファイルへのアクセスや破壊的 API 呼び出しを許可してしまう
+- `settings.local.json` は `.gitignore` 済みのため、machine-specific な設定や一時的な権限緩和はそちらで設定する
 - 絶対パスの deny パターンは `//` プレフィックスで指定する（例: `Read(//Users/*/.aws/credentials)`）

--- a/src/.claude/settings.personal.json
+++ b/src/.claude/settings.personal.json
@@ -1,6 +1,5 @@
 {
   "env": {
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
     "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet",
     "ENABLE_TOOL_SEARCH": "true"

--- a/src/.claude/settings.work.json
+++ b/src/.claude/settings.work.json
@@ -1,7 +1,6 @@
 {
   "effortLevel": "high",
   "env": {
-    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
     "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet",
     "ENABLE_TOOL_SEARCH": "true"


### PR DESCRIPTION

## 📒 Summary of Changes

- ✏️ ADRノートの文言を修正。
- ✅ Claude設定で1Mコンテキストを有効化。

## ⚒ Technical Details

- 🔧 `docs/adr/0006-claude-code-settings-management.md`の注意事項を修正。
- ⚙️ `src/.claude/settings.personal.json`および`src/.claude/settings.work.json`から`CLAUDE_CODE_DISABLE_1M_CONTEXT`の設定を削除。