### PR TITLE
🐛 CI flaky を修正するための lint スクリプトの改善と gitconfig の更新

### DIFF
--- a/scripts/lint/mixed-line-ending.sh
+++ b/scripts/lint/mixed-line-ending.sh
@@ -20,8 +20,10 @@ for f in "${files[@]}"; do
   [[ -f "$f" ]] || continue
   grep -Iq . "$f" || continue
   if grep -q $'\r' "$f"; then
+    # cp -p でパーミッションを引き継いでから mv で atomic に置換する。
+    # truncate して書き戻すと parallel 実行中の linter が書き込み途中を読む。
+    cp -p "$f" "$f.tmp"
     tr -d '\r' <"$f" >"$f.tmp"
-    cat "$f.tmp" >"$f"
-    rm -f "$f.tmp"
+    mv -f "$f.tmp" "$f"
   fi
 done

--- a/scripts/lint/trailing-whitespace.sh
+++ b/scripts/lint/trailing-whitespace.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 for f in "$@"; do
   [[ -f "$f" ]] || continue
   grep -Iq . "$f" || continue
+  # cp -p でパーミッションを引き継いでから mv で atomic に置換する。
+  # truncate して書き戻すと parallel 実行中の linter が書き込み途中を読む。
+  cp -p "$f" "$f.tmp"
   sed -E 's/[[:space:]]+$//' "$f" >"$f.tmp"
-  cat "$f.tmp" >"$f"
-  rm -f "$f.tmp"
+  mv -f "$f.tmp" "$f"
 done

--- a/src/.gitconfig
+++ b/src/.gitconfig
@@ -9,6 +9,15 @@
 [push]
 	default = simple
 	autoSetupRemote = true
+[pull]
+	rebase = true
+[fetch]
+	prune = true
+	pruneTags = true
+[branch]
+	autoSetupMerge = inherit
+[rebase]
+	autoStash = true
 [diff]
 	tool = default-difftool
 [difftool "default-difftool"]

--- a/src/.gitconfig.work
+++ b/src/.gitconfig.work
@@ -6,6 +6,15 @@
 [push]
 	default = simple
 	autoSetupRemote = true
+[pull]
+	rebase = true
+[fetch]
+	prune = true
+	pruneTags = true
+[branch]
+	autoSetupMerge = inherit
+[rebase]
+	autoStash = true
 [commit]
 	gpgsign = false
 [alias]


### PR DESCRIPTION

## 📒 Summary of Changes

- 🔧 lint スクリプトでの `truncate` 書き戻しによる CI flaky を修正。
- 🛠 `gitconfig` を更新し、`git pull` で最新ソースを取得できるように設定。

## ⚒ Technical Details

- 🔄 `scripts/lint/mixed-line-ending.sh` と `scripts/lint/trailing-whitespace.sh` で、ファイルのパーミッションを保持しつつ atomic に置換するために `cp -p` と `mv` を使用。
- ⚙️ `src/.gitconfig` と `src/.gitconfig.work` に以下の設定を追加：
  - `pull.rebase` を `true` に設定。
  - `fetch` に `prune` と `pruneTags` を追加。
  - `branch.autoSetupMerge` を `inherit` に設定。
  - `rebase.autoStash` を `true` に設定。

## ⚠ Points of Caution

- ⚠️ lint スクリプトの変更により、並行実行中の linter が書き込み途中のファイルを読み込む可能性があるため、注意が必要です。